### PR TITLE
feat: canvas scaling for "high quality" output

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,11 @@
             <span class="flex-1"><span class="mr-2">Y</span><input type="number" placeholder="Type here" value="0"
                 class="input input-bordered input-sm input-primary w-32" id="graphY" /></span>
           </div>
+          <div class="flex items-center gap-2 my-4">
+            <div class="i18n" data-i18n="scale-level">Scale Level</div>
+            <input type="number" placeholder="1" value="1" min="1" max="4"
+                class="input input-bordered input-sm input-primary w-32" id="scaleLevel" />
+          </div>
         </div>
       </div>
     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,6 +7,7 @@
   "transparent-background": "Transparent Background",
   "advance": "Advance settings",
   "halo-cross": "Halo & Cross position",
+  "scale-level": "Scale Level",
   "font-title": "Used Fonts",
   "main-font": "Main font: ",
   "fallback-font": "Fallback font: ",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -7,6 +7,7 @@
   "transparent-background": "透明背景",
   "advance": "高级设置",
   "halo-cross": "光环位置微调",
+  "scale-level": "缩放等级",
   "font-title": "使用的字体",
   "main-font": "主要字体：",
   "fallback-font": "Fallback 字体：",

--- a/src/style.css
+++ b/src/style.css
@@ -39,7 +39,7 @@ h1 {
 #canvas {
   border-radius: 8px;
   border: 1px solid #bbb;
-  max-width: 100%;
+  max-width: 900px;
 }
 
 @media (max-width: 900px){

--- a/src/utils/loadFont.ts
+++ b/src/utils/loadFont.ts
@@ -1,6 +1,6 @@
 import settings from '../settings';
 
-export default async (content: string = 'A') => {
+export default async (content: string = 'A', scaleLevel: number = 1) => {
   // const G2B = new FontFace('G2B', 'url(../RoGSanSrfStd-Bd_other.woff2)');
   // // const GSH = new FontFace('GSH', 'url(../GlowSansSC-Normal-Heavy.otf)');
   // await Promise.all([G2B.load() /*, GSH.load()*/]).then((fonts) =>
@@ -9,7 +9,7 @@ export default async (content: string = 'A') => {
   // const loadingSwitch = document.querySelector('#loading-switch') as HTMLInputElement;
   // loadingSwitch.checked = true;
   await document.fonts.load(
-    `${settings.fontSize}px RoGSanSrfStd-Bd, GlowSansSC-Normal-Heavy_diff`,
+    `${settings.fontSize * scaleLevel}px RoGSanSrfStd-Bd, GlowSansSC-Normal-Heavy_diff`,
     content
   );
   // loadingSwitch.checked = false;


### PR DESCRIPTION
Adding canvas scaling option for someone doesn't satisfied with 250p output and someone using HiDPI screen.

Also hard-coded max width of the canvas element so scaling won't messing up the layout.

Side note: Be better to use SVG instead of PNG for halo and cross texture, there's another PR already doing that: #6

## Preview
![image](https://github.com/nulla2011/bluearchive-logo/assets/36147447/43480aa0-8cf6-40ff-b78b-02346bde1fd1)

Default 1x output:
![DarkArchive_ba-style@nulla top 1x](https://github.com/nulla2011/bluearchive-logo/assets/36147447/73918ea7-bc68-41d0-9570-61966b2ce7d0)

2x output:
![DarkArchive_ba-style@nulla top 2x](https://github.com/nulla2011/bluearchive-logo/assets/36147447/c2a47738-b18d-424e-a00d-b196091c6564)
